### PR TITLE
[feature] Ajout de la classe `ApplicationAuditAware` pour l'audit JPA des champs `createdBy` et `lastModifiedBy`

### DIFF
--- a/src/main/java/com/fzamiche/back_book_social_network/BackBookSocialNetworkApplication.java
+++ b/src/main/java/com/fzamiche/back_book_social_network/BackBookSocialNetworkApplication.java
@@ -10,24 +10,28 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
-@EnableJpaAuditing  // pour activer l'auditeur JPA
-@EnableAsync 	  // pour activer l'envoi d'email en asynchrone
+/*
+	Pour activer l'auditeur JPA, qui permet de gérer les champs createdDate, lastModifiedDate,
+	Et pour les champs createdBy et lastModifiedBy, il faut implémenter l'interface AuditorAware.
+*/
+@EnableJpaAuditing(auditorAwareRef = "auditorAware") // on précise le bean qui va gérer les champs createdBy et lastModifiedBy
+@EnableAsync      // pour activer l'envoi d'email en asynchrone
 public class BackBookSocialNetworkApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BackBookSocialNetworkApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(BackBookSocialNetworkApplication.class, args);
+    }
 
-	@Bean
-	public CommandLineRunner commandLineRunner(RoleRepository roleRepository) {
-		return args -> {
-			if(roleRepository.findByName("USER").isEmpty()){
-				roleRepository.save(
-						Role.builder()
-								.name("USER")
-								.build()
-				);
-			}
-		};
-	}
+    @Bean
+    public CommandLineRunner commandLineRunner(RoleRepository roleRepository) {
+        return args -> {
+            if (roleRepository.findByName("USER").isEmpty()) {
+                roleRepository.save(
+                        Role.builder()
+                                .name("USER")
+                                .build()
+                );
+            }
+        };
+    }
 }

--- a/src/main/java/com/fzamiche/back_book_social_network/config/ApplicationAuditAware.java
+++ b/src/main/java/com/fzamiche/back_book_social_network/config/ApplicationAuditAware.java
@@ -1,0 +1,30 @@
+package com.fzamiche.back_book_social_network.config;
+
+
+import com.fzamiche.back_book_social_network.user.User;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+
+/**
+ * Cette classe permet de gérer les champs createdBy et lastModifiedBy
+ * à partir de SecurityContextHolder on récupère l'utilisateur connecté
+ * et on retourne son id
+ */
+public class ApplicationAuditAware implements AuditorAware<Integer> {
+    @Override
+    public Optional<Integer> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null ||
+                !authentication.isAuthenticated()
+                || authentication instanceof AnonymousAuthenticationToken) {
+            return Optional.of(0);
+        }
+        User userPrincipal =  (User) authentication.getPrincipal();
+        return Optional.ofNullable(userPrincipal.getId()); // ofNullable pour éviter les nullPointerException, si l'utilisateur n'est pas connecté on retourne 0
+    }
+}

--- a/src/main/java/com/fzamiche/back_book_social_network/config/BeansConfig.java
+++ b/src/main/java/com/fzamiche/back_book_social_network/config/BeansConfig.java
@@ -3,6 +3,7 @@ package com.fzamiche.back_book_social_network.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -33,5 +34,10 @@ public class BeansConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public AuditorAware<Integer> auditorAware() {
+        return new ApplicationAuditAware();
     }
 }


### PR DESCRIPTION
Cette feature permet de gérer automatiquement les champs `createdBy` et `lastModifiedBy` en utilisant `SecurityContextHolder` pour récupérer l'ID de l'utilisateur.